### PR TITLE
Fix Restart Command & Spotify Credentials (#2329)

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -133,6 +133,7 @@ class MusicBot(discord.Client):
                     aiosession=self.session,
                     loop=self.loop,
                 )
+                await self.spotify.get_token()
                 if not self.spotify.token:
                     log.warning("Spotify did not provide us with a token. Disabling.")
                     self.config._spotify = False
@@ -560,7 +561,7 @@ class MusicBot(discord.Client):
         await self.update_now_playing_status(entry)
         player.skip_state.reset()
 
-        # This is the one event where its ok to serialize autoplaylist entries
+        # This is the one event where it's ok to serialize autoplaylist entries
         await self.serialize_queue(player.voice_client.channel.guild)
 
         if self.config.write_current_song:
@@ -1037,7 +1038,7 @@ class MusicBot(discord.Client):
 
     async def _cleanup(self):
         try:
-            self.loop.run_until_complete(self.logout())
+            self.loop.run_until_complete(await self.logout())
             self.loop.run_until_complete(self.session.close())
         except:
             pass

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -6,22 +6,28 @@ import yt_dlp as youtube_dl
 
 from concurrent.futures import ThreadPoolExecutor
 
+from types import MappingProxyType
+
 log = logging.getLogger(__name__)
 
-ytdl_format_options = {
-    "format": "bestaudio/best",
-    "outtmpl": "%(extractor)s-%(id)s-%(title)s.%(ext)s",
-    "restrictfilenames": True,
-    "noplaylist": True,
-    "nocheckcertificate": True,
-    "ignoreerrors": False,
-    "logtostderr": False,
-    "quiet": True,
-    "no_warnings": True,
-    "default_search": "auto",
-    "source_address": "0.0.0.0",
-    "usenetrc": True,
-}
+# Immutable dict is needed, because something is modifying the 'outtmpl' value. I suspect it being ytdl, but I'm not sure.
+ytdl_format_options_immutable = MappingProxyType(
+    {
+        "format": "bestaudio/best",
+        "outtmpl": "%(extractor)s-%(id)s-%(title)s.%(ext)s",
+        "restrictfilenames": True,
+        "noplaylist": True,
+        "nocheckcertificate": True,
+        "ignoreerrors": False,
+        "logtostderr": False,
+        "quiet": True,
+        "no_warnings": True,
+        "default_search": "auto",
+        "source_address": "0.0.0.0",
+        "usenetrc": True,
+    }
+)
+
 
 # Fuck your useless bugreports message that gets two link embeds and confuses users
 youtube_dl.utils.bug_reports_message = lambda: ""
@@ -39,6 +45,9 @@ class Downloader:
     def __init__(self, download_folder=None):
         self.thread_pool = ThreadPoolExecutor(max_workers=2)
         self.download_folder = download_folder
+
+        # Copy immutable dict and use the mutable copy for everything else.
+        ytdl_format_options = ytdl_format_options_immutable.copy()
 
         if download_folder:
             # print("setting template to " + os.path.join(download_folder, otmpl))

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -407,9 +407,7 @@ class URLPlaylistEntry(BasePlaylistEntry):
             log.debug("Could not parse TP in normalise json.")
             TP = float(0)
 
-        thresh_matches = re.findall(
-            r'"input_thresh" : "(-?([0-9]*\.[0-9]+))",', output
-        )
+        thresh_matches = re.findall(r'"input_thresh" : "(-?([0-9]*\.[0-9]+))",', output)
         if thresh_matches:
             log.debug("thresh_matches={}".format(thresh_matches[0][0]))
             thresh = float(thresh_matches[0][0])
@@ -417,9 +415,7 @@ class URLPlaylistEntry(BasePlaylistEntry):
             log.debug("Could not parse thresh in normalise json.")
             thresh = float(0)
 
-        offset_matches = re.findall(
-            r'"target_offset" : "(-?([0-9]*\.[0-9]+))', output
-        )
+        offset_matches = re.findall(r'"target_offset" : "(-?([0-9]*\.[0-9]+))', output)
         if offset_matches:
             log.debug("offset_matches={}".format(offset_matches[0][0]))
             offset = float(offset_matches[0][0])

--- a/musicbot/spotify.py
+++ b/musicbot/spotify.py
@@ -1,5 +1,6 @@
 import aiohttp
 import asyncio
+import asyncio.exceptions
 import base64
 import logging
 import time
@@ -10,9 +11,7 @@ log = logging.getLogger(__name__)
 
 
 def _make_token_auth(client_id, client_secret):
-    auth_header = base64.b64encode(
-        (client_id + ":" + client_secret).encode("ascii")
-    )
+    auth_header = base64.b64encode((client_id + ":" + client_secret).encode("ascii"))
     return {"Authorization": "Basic %s" % auth_header.decode("ascii")}
 
 
@@ -35,6 +34,8 @@ class Spotify:
         self.loop = loop if loop else asyncio.get_event_loop()
 
         self.token = None
+
+        self.max_token_tries = 2
 
     async def get_track(self, uri):
         """Get a track's info from its URI"""
@@ -117,25 +118,47 @@ class Spotify:
 
     async def request_token(self):
         """Obtains a token from Spotify and returns it"""
-        payload = {"grant_type": "client_credentials"}
-        headers = _make_token_auth(self.client_id, self.client_secret)
-        r = await self.make_post(self.OAUTH_TOKEN_URL, payload=payload, headers=headers)
-        return r
+        try:
+            payload = {"grant_type": "client_credentials"}
+            headers = _make_token_auth(self.client_id, self.client_secret)
+            r = await self.make_post(
+                self.OAUTH_TOKEN_URL, payload=payload, headers=headers
+            )
+            return r
+        except asyncio.exceptions.CancelledError as e:  # see request_guest_token()
+            if self.max_token_tries == 0:
+                raise e
+
+            self.max_token_tries -= 1
+            return await self.request_token()
 
     async def request_guest_token(self):
         """Obtains a web player token from Spotify and returns it"""
-        async with self.aiosession.get(
-            "https://open.spotify.com/get_access_token?reason=transport&productType=web_player"
-        ) as r:
-            if r.status != 200:
-                try:
-                    raise SpotifyError(
-                        "Issue generating guest token: [{0.status}] {1}".format(
-                            r, await r.json()
+        try:
+            async with self.aiosession.get(
+                "https://open.spotify.com/get_access_token?reason=transport&productType=web_player"
+            ) as r:
+                if r.status != 200:
+                    try:
+                        raise SpotifyError(
+                            "Issue generating guest token: [{0.status}] {1}".format(
+                                r, await r.json()
+                            )
                         )
-                    )
-                except aiohttp.ContentTypeError as e:
-                    raise SpotifyError(
-                        "Issue generating guest token: [{0.status}] {1}".format(r, e)
-                    )
-            return await r.json()
+                    except aiohttp.ContentTypeError as e:
+                        raise SpotifyError(
+                            "Issue generating guest token: [{0.status}] {1}".format(
+                                r, e
+                            )
+                        )
+                return await r.json()
+        except (
+            asyncio.exceptions.CancelledError
+        ) as e:  # fails to generate after a restart, but succeeds if you just try again
+            if (
+                self.max_token_tries == 0
+            ):  # Unfortunately this logic has to be here, because if just tried
+                raise e  # to get a token in get_token() again it fails for some reason
+
+            self.max_token_tries -= 1
+            return await self.request_guest_token()


### PR DESCRIPTION
* fixed the restart command

* ran black

* added `and not player` back in. also fixed spotify not being able to use credentials

* fixed the bot crashing on a restart when using client ID and secret

* one last black

---------

Co-authored-by: BabyBoySnow

After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.8 or higher
- [ ] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description



### Related issues (if applicable)

